### PR TITLE
myriad/services_lifecycle

### DIFF
--- a/lib/Myriad/Registry.pm
+++ b/lib/Myriad/Registry.pm
@@ -67,7 +67,7 @@ async method add_service (%args) {
     $sink->{$pkg} ||= {};
     $emitter->{$pkg} ||= {};
     $receiver->{$pkg} ||= {};
-    $log->infof('Add service [%s]', $name);
+    $log->tracef('Going to add service %s', $name);
     $self->loop->add(
         $srv
     );
@@ -75,7 +75,12 @@ async method add_service (%args) {
     weaken($service_by_name->{$name} = $srv);
     $self->{services}{$k} = $srv;
 
-    await $srv->start;
+    try {
+        await $srv->start;
+        $log->infof('Added service [%s]', $name);
+    } catch ($e) {
+        $log->errorf('Failed to add service [%s] due: %s', $name, $e);
+    }
     return;
 }
 

--- a/lib/Myriad/Registry.pm
+++ b/lib/Myriad/Registry.pm
@@ -75,7 +75,7 @@ async method add_service (%args) {
     weaken($service_by_name->{$name} = $srv);
     $self->{services}{$k} = $srv;
 
-    await $srv->startup;
+    await $srv->start;
     return;
 }
 

--- a/lib/Myriad/Service/Implementation.pm
+++ b/lib/Myriad/Service/Implementation.pm
@@ -93,7 +93,7 @@ The name of the service, defaults to the package name.
 
 =cut
 
-method service_name () { $service_name //= lc(ref($self) =~ s{::}{_}gr) }
+method service_name () { $service_name //= lc(ref($self) =~ s{::}{.}gr) }
 
 =head2 subscription_transport
 

--- a/lib/Myriad/Service/Implementation.pm
+++ b/lib/Myriad/Service/Implementation.pm
@@ -146,7 +146,7 @@ This will trigger a number of actions:
 
 =cut
 
-async method _add_to_loop($loop) {
+method _add_to_loop($loop) {
     $log->tracef('Adding %s to loop', ref $self);
     $self->next::method($loop);
 }

--- a/lib/Myriad/Service/Implementation.pm
+++ b/lib/Myriad/Service/Implementation.pm
@@ -146,103 +146,8 @@ This will trigger a number of actions:
 
 =cut
 
-method _add_to_loop($loop) {
+async method _add_to_loop($loop) {
     $log->tracef('Adding %s to loop', ref $self);
-    my $registry = $Myriad::REGISTRY;
-    $self->add_child(
-        $ryu = Ryu::Async->new
-    );
-
-    $self->add_child(
-        $sub = Myriad::Subscription->new(
-            transport => $self->subscription_transport,
-            redis     => $redis,
-            service   => ref($self),
-            ryu       => $ryu
-        )
-    );
-
-    if(my $emitters = $registry->emitters_for(ref($self))) {
-        for my $method (sort keys $emitters->%*) {
-            $log->tracef('Found emitter %s as %s', $method, $emitters->{$method});
-            my $spec = $emitters->{$method};
-            my $chan = $spec->{args}{channel} // die 'expected a channel, but there was none to be found';
-            my $sink = $ryu->sink(
-                label => "emitter:$chan",
-            );
-            $sub->create_from_source(
-                source => $sink->source,
-                channel => $chan,
-            );
-            my $code = $spec->{code};
-            $spec->{current} = $self->$code(
-                $sink,
-                $self,
-            )->retain;
-        }
-    }
-
-    if(my $receivers = $registry->receivers_for(ref($self))) {
-        for my $method (sort keys $receivers->%*) {
-            $log->tracef('Found receiver %s as %s', $method, $receivers->{$method});
-            my $spec = $receivers->{$method};
-            my $chan = $spec->{args}{channel} // die 'expected a channel, but there was none to be found';
-            my $sink = $ryu->sink(
-                label => "receiver:$chan",
-            );
-            $sub->create_from_sink(
-                sink => $sink,
-                channel => $chan,
-                client => ref($self) . '/' . $method,
-            );
-            my $code = $spec->{code};
-            $spec->{current} = $self->$code(
-                $sink->source,
-                $self,
-            )->retain;
-        }
-    }
-    if (my $batches = $registry->batches_for(ref($self))) {
-        for my $k (sort keys $batches->%*) {
-            $log->tracef('Starting batch process %s for %s', $k, ref($self));
-            my $code = $batches->{$k};
-            my $src = $self->ryu->source(label => 'batch:' . $k);
-            $active_batch{$k} = [
-                $src,
-                $self->process_batch($k, $code, $src)
-            ];
-        }
-    }
-
-    if (my $rpc_calls = $registry->rpc_for(ref($self))) {
-        $self->add_child(
-            $rpc = Myriad::RPC->new(
-                transport => $self->rpc_transport,
-                redis   => $redis,
-                service => ref($self),
-            )
-        ) if %$rpc_calls;
-
-        for my $method (sort keys $rpc_calls->%*) {
-            my $spec = $rpc_calls->{$method};
-            my $sink = $ryu->sink(label => "rpc:$method");
-            $rpc->create_from_sink(method => $method, sink => $sink);
-
-            my $code = $spec->{code};
-            $spec->{current} = $sink->source->map(async sub {
-                my $message = shift;
-                try {
-                    my $response = await $self->$code($message->args->%*);
-                    await $rpc->reply_success($message, $response);
-                } catch ($e) {
-                    await $rpc->reply_error($message, $e);
-                }
-            })->resolve->completed;
-        }
-
-
-    }
-
     $self->next::method($loop);
 }
 
@@ -272,27 +177,139 @@ async method process_batch($k, $code, $src) {
     }
 }
 
-=head2 startup
+=head2 start
 
-Start the service and perform any operation needed before announcing the service as ready to start
+Perform the diagnostics check and start the service components (RPC, Batches, Subscriptions ..etc).
 
 =cut
 
-async method startup {
+async method start {
+    my $registry = $Myriad::REGISTRY;
+    await $self->startup;
+    if (await $self->diagnostics(1)) {
+        $self->add_child(
+            $ryu = Ryu::Async->new
+        ); 
+
+        $self->add_child(
+            $sub = Myriad::Subscription->new(
+                transport => $self->subscription_transport,
+                redis     => $redis,
+                service   => ref($self),
+                ryu       => $ryu
+            )
+        );
+
+        if(my $emitters = $registry->emitters_for(ref($self))) {
+            for my $method (sort keys $emitters->%*) {
+                $log->tracef('Found emitter %s as %s', $method, $emitters->{$method});
+                my $spec = $emitters->{$method};
+                my $chan = $spec->{args}{channel} // die 'expected a channel, but there was none to be found';
+                my $sink = $ryu->sink(
+                    label => "emitter:$chan",
+                );
+                $sub->create_from_source(
+                    source => $sink->source,
+                    channel => $chan,
+                );
+                my $code = $spec->{code};
+                $spec->{current} = $self->$code(
+                    $sink,
+                    $self,
+                )->retain;
+            }
+        }
+
+        if(my $receivers = $registry->receivers_for(ref($self))) {
+            for my $method (sort keys $receivers->%*) {
+                $log->tracef('Found receiver %s as %s', $method, $receivers->{$method});
+                my $spec = $receivers->{$method};
+                my $chan = $spec->{args}{channel} // die 'expected a channel, but there was none to be found';
+                my $sink = $ryu->sink(
+                    label => "receiver:$chan",
+                );
+                $sub->create_from_sink(
+                    sink => $sink,
+                    channel => $chan,
+                    client => ref($self) . '/' . $method,
+                );
+                my $code = $spec->{code};
+                $spec->{current} = $self->$code(
+                    $sink->source,
+                    $self,
+                )->retain;
+            }
+        }
+        if (my $batches = $registry->batches_for(ref($self))) {
+            for my $k (sort keys $batches->%*) {
+                $log->tracef('Starting batch process %s for %s', $k, ref($self));
+                my $code = $batches->{$k};
+                my $src = $self->ryu->source(label => 'batch:' . $k);
+                $active_batch{$k} = [
+                    $src,
+                    $self->process_batch($k, $code, $src)
+                ];
+            }
+        }
+
+        if (my $rpc_calls = $registry->rpc_for(ref($self))) {
+            $self->add_child(
+                $rpc = Myriad::RPC->new(
+                    transport => $self->rpc_transport,
+                    redis   => $redis,
+                    service => ref($self),
+                )
+            ) if %$rpc_calls;
+
+            for my $method (sort keys $rpc_calls->%*) {
+                my $spec = $rpc_calls->{$method};
+                my $sink = $ryu->sink(label => "rpc:$method");
+                $rpc->create_from_sink(method => $method, sink => $sink);
+
+                my $code = $spec->{code};
+                $spec->{current} = $sink->source->map(async sub {
+                    my $message = shift;
+                    try {
+                        my $response = await $self->$code($message->args->%*);
+                        await $rpc->reply_success($message, $response);
+                    } catch ($e) {
+                        await $rpc->reply_error($message, $e);
+                    }
+                })->resolve->completed;
+            }
+
+
+        }
+    }
+
     my $wait_sub = $sub->start->on_fail(sub { $log->errorf('failed on sub run - %s', [ @_ ]) });
     my $wait_rpc = $rpc ? $rpc->start : Future->done;
 
     await Future->wait_all($wait_sub, $wait_rpc);
 };
 
+=head2 startup
+
+Initialize the service internal status it will be called when the service is added to the L<IO::Async::Loop>.
+
+The method here is just a placeholder it should be reimplemented by the service code.
+
+=cut
+
+async method startup {
+    return;
+}
+
 =head2 diagnostics
 
 Runs any internal diagnostics.
 
+The method here is just a placeholder it should be reimplemented by the service code.
+
 =cut
 
-async method diagnostics {
-    return;
+async method diagnostics($level) {
+    return 'ok';
 }
 
 =head2 shutdown

--- a/lib/Myriad/Service/Implementation.pm
+++ b/lib/Myriad/Service/Implementation.pm
@@ -212,7 +212,7 @@ async method start {
             $self->loop->timeout_future(after => 10),
             $self->diagnostics(1),
         );
-        
+
         if ($diagnostics_ok) {
             if(my $emitters = $registry->emitters_for(ref($self))) {
                 for my $method (sort keys $emitters->%*) {
@@ -295,7 +295,7 @@ async method start {
         my $wait_rpc = $rpc ? $rpc->start : Future->done;
 
         Future->wait_all($wait_sub, $wait_rpc)->retain;
-    
+
     } catch ($e) {
         $log->errorf('Could not finish diagnostics for service %s in time.', $self->service_name);
         die $e;

--- a/lib/Myriad/Subscription/Implementation/Redis.pm
+++ b/lib/Myriad/Subscription/Implementation/Redis.pm
@@ -40,7 +40,7 @@ method configure (%args) {
 
 method create_from_source (%args) {
     my $src = delete $args{source} or die 'need a source';
-    my $stream = $service . '.' . $args{channel};
+    my $stream = $service . '/' . $args{channel};
     $src->each(sub {
         $log->tracef('sub has an event! %s', $_);
         $redis->xadd(
@@ -52,7 +52,7 @@ method create_from_source (%args) {
 
 method create_from_sink (%args) {
     my $sink = delete $args{sink} or die 'need a sink';
-    my $stream = $service . '.' . $args{channel};
+    my $stream = $service . '/' . $args{channel};
     $log->tracef('created sub thing from sink');
     push $queues->@*, {
         key => $stream,


### PR DESCRIPTION
So this will include braking changes to the Redis namespaces: 
- all services will have a namespace derived from its package name for example if the service is `Example::Service` its namespace is now `example.service` see the `Myriad/Service/Implementation#service_name`.
- Redis keys will have `/` to separate between the service name and the subscription method name.
- Redis RPC is now `<namespace>/rpc`.

Will open another PR to make the fixed timeout values in `Myriad/Service/Implementation.pm` configurable.