### PR TITLE
Use officially documented way to obtain Object::Pad's metaclasses

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -9,7 +9,7 @@ requires 'Syntax::Keyword::Defer', '>= 0.05';
 requires 'Future', '>= 0.47';
 requires 'Future::Queue';
 requires 'Future::AsyncAwait', '>= 0.50';
-requires 'Object::Pad', '>= 0.37';
+requires 'Object::Pad', '>= 0.38';
 requires 'Role::Tiny', '>= 2.002004';
 # Streams
 requires 'Ryu', '>= 3.000';

--- a/lib/Myriad/Service/Storage.pm
+++ b/lib/Myriad/Service/Storage.pm
@@ -31,7 +31,7 @@ BEGIN {
         labels => [qw(method status service)],
     );
 
-    my $meta = Myriad::Service::Storage->META;
+    my $meta = Object::Pad::MOP::Class->for_class('Myriad::Service::Storage');
     for my $method (@Myriad::Role::Storage::WRITE_METHODS, @Myriad::Role::Storage::READ_METHODS) {
         $meta->add_method($method, sub {
             my ($self, $key, @rest) = @_;

--- a/lib/Myriad/Service/Storage/Remote.pm
+++ b/lib/Myriad/Service/Storage/Remote.pm
@@ -32,7 +32,7 @@ BEGIN {
         labels => [qw(method status service)],
     );
 
-    my $meta = Myriad::Service::Storage::Remote->META;
+    my $meta = Object::Pad::MOP::Class->for_class('Myriad::Service::Storage::Remote');
 
     for my $method (@Myriad::Role::Storage::READ_METHODS) {
         $meta->add_method($method, sub {

--- a/lib/Test/Myriad.pm
+++ b/lib/Test/Myriad.pm
@@ -56,7 +56,7 @@ sub add_service {
     my ($pkg, $meta);
     if (my $service = delete $args{service}) {
         $pkg = $service;
-        $meta = $service->META;
+        $meta = Object::Pad::MOP::Class->for_class(ref $service);
     } elsif ($service = delete $args{name}) {
         die 'The name should look like a Perl package name' unless $service =~ /::/;
         $pkg  = $service;

--- a/t/commands.t
+++ b/t/commands.t
@@ -53,9 +53,11 @@ subtest "service command" => sub {
     $INC{'Ta/Sibling2.pm'} = 1;
     ######
 
+    my $metaclass = Object::Pad::MOP::Class->for_class('Myriad');
+
     my $myriad = Myriad->new;
     my $command = new_ok('Myriad::Commands'=> ['myriad', $myriad]);
-    $myriad->META->get_slot('$config')->value($myriad) = Myriad::Config->new();
+    $metaclass->get_slot('$config')->value($myriad) = Myriad::Config->new();
 
     # Wrong Service(module) name
     like( exception { wait_for_future( $command->service('Ta-wrong') )->get } , qr/unsupported/, 'Died when passing wrong format name');
@@ -69,7 +71,7 @@ subtest "service command" => sub {
 
     # Command to run multiple services should not be allowed when service_name option is set
     my $srv_run_name = 'service.test.one';
-    $myriad->META->get_slot('$config')->value($myriad) = Myriad::Config->new( commandline => ['--service_name', $srv_run_name] );
+    $metaclass->get_slot('$config')->value($myriad) = Myriad::Config->new( commandline => ['--service_name', $srv_run_name] );
     like (exception {wait_for_future( $command->service('Ta::') )->get}, qr/You cannot pass a service/, 'Not able to load multiple due to set service_name');
     # However allowed to run 1
     wait_for_future( $command->service('Ta::Sibling1')->get->{code}->() )->get;

--- a/t/myriad.t
+++ b/t/myriad.t
@@ -24,7 +24,7 @@ my $command_is_called = 0;
 $command_module->mock($command, async sub { my ($self, $param) = @_; $command_is_called = $param; });
 
 my $myriad = new_ok('Myriad');
-my $metaclass = $myriad->META;
+my $metaclass = Object::Pad::MOP::Class->for_class('Myriad');
 my $loop = $myriad->loop;
 testing_loop($loop);
 


### PR DESCRIPTION
Object::Pad version 0.38 added officially-documented ways to obtain the metaclass for a given class, replacing the "words in practice" but undocumented `->META` internal implementation detail. These should be used instead for future compatibility.