### PR TITLE
Standardise on singular terminology

### DIFF
--- a/lib/Myriad/Config.pm
+++ b/lib/Myriad/Config.pm
@@ -50,6 +50,7 @@ alternative.
 # Default values
 
 our %DEFAULTS = (
+    services               => { },
     config_path            => 'config.yml',
     transport_redis        => 'redis://localhost:6379',
     transport_redis_cache  => 0,
@@ -84,7 +85,7 @@ our %FULLNAME_FOR = (
 
 =head2 SERVICES_CONFIG
 
-A registry of configs defined by the services using the C<< config  >> helper.
+A registry of service configuration defined by the services using the C<< config >> helper.
 
 =cut
 
@@ -92,7 +93,8 @@ our %SERVICES_CONFIG;
 
 =head2 ACTIVE_SERVICES_CONFIG
 
-A collection of L<Ryu::Observable> to notify services about updates on the configs values
+A collection of L<Ryu::Observable> instances for notifying services about updates on their
+configuration.
 
 =cut
 
@@ -167,61 +169,57 @@ the best use case for this sub is during tests.
 =cut
 
 method clear_all {
-    $config = {};
+    $config = {
+        services               => { },
+    };
 }
 
 =head2 parse_subargs
 
 A helper to resolve the correct service config
 
-input is expected to look like <service_name>_[configs|instances].<key>
+input is expected to look like:
+
+ <service_name>_[config|instance].<key>
 
 and this sub will set the correct path to key with the provided value.
 
 Example:
 
-dummy_service.configs.password
+ dummy_service.config.password
 
 will end up in
 
-$config->{services}->{dummy_service}->{configs}->{password}
+ $config->{services}->{dummy_service}->{config}->{password}
 
-it takes:
+Takes the following parameters:
 
 =over 4
 
-=item * C<subarg> - the arguments as passed by the user.
+=item * C<$subarg> - the arguments as passed by the user.
 
-=item * C<root> - the level in which we should add the sub arg, we start from $config->{services}.
+=item * C<$root> - the level in which we should add the sub arg, we start from $config->{services}.
 
-=item * C<value> - the value that we should assign after resolving the config path.
+=item * C<$value> - the value that we should assign after resolving the config path.
 
 =back
 
 =cut
 
 method parse_subargs ($subarg, $root, $value) {
-    my $service_name = $subarg =~ s/(.*?)[_|\.](configs?|instances?)(.*)/$2$3/ && $1;
-    die 'invalid service name' unless $2;
+    my $instance = $subarg =~ s{[_.]instance[_.](.*)(?=[_.]config)}{} && $1;
+    my $config = $subarg =~ s{[_.]config[_.](.*)$}{} && $1;
 
-    $service_name =~ s/_/\./g;
-    $root = $root->{$service_name} //= {};
+    my $service_name = $subarg =~ tr/_/./r;
+    $instance = $instance =~ tr/_/./r if $instance;
+    $config = $config =~ tr/./_/r if $config;
 
-    my @sublist = split /_|\./, $subarg;
-    die 'config key is not formated correctly' unless @sublist;
-
-    # configs is the latest level before starting a keyname
-    # Also users might pass config instead of configs
-    while ($sublist[0] !~ s/(config)s?/$1s/) {
-        my $level = shift @sublist;
-        $level .= 's' if $level eq 'instance';
-
-        $root->{$level} //= {};
-        $root= $root->{$level};
+    die 'invalid service name' unless length $service_name;
+    if(length $instance) {
+        $root->{$service_name}{instance}{$instance}{config}{$config} = $value;
+    } else {
+        $root->{$service_name}{config}{$config} = $value;
     }
-    shift @sublist;
-    my $key_name = join '_', @sublist;
-    $root->{configs}->{$key_name} = $value;
 }
 
 =head2 lookup_from_args
@@ -229,13 +227,13 @@ method parse_subargs ($subarg, $root, $value) {
 Parse the arguments provided from the command line.
 
 There are many modules that can parse command lines arguments
-but in our case we have unknown arguments - the services configs - that
+but in our case we have unknown arguments - the services config - that
 might be passed by the user or might not and they are on top of that nested.
 
 This sub simply start looking for a match for the arg at hand in C<%DEFAULTS>
 then it searches in the shortcuts map and lastly it tries to parse it as a subarg.
 
-Currently this sub takes into account flags (0|1) configs and config written as:
+Currently this sub takes into account flags (0|1) config and config written as:
 config=value
 
 
@@ -258,7 +256,7 @@ method lookup_from_args ($commandline) {
             # Either `--example=123` or `--example 123`
             $value = shift $commandline->@* unless defined $value;
             $config->{$key} = $value;
-        } elsif ($arg =~ s/services?[_|\.]//) { # are we doing service config
+        } elsif ($arg =~ s/service[_|\.]//) { # are we doing service config
             $value = shift $commandline->@* unless $value;
             try {
                 $self->parse_subargs($arg, $config->{services}, $value);
@@ -280,16 +278,23 @@ method lookup_from_args ($commandline) {
 
 =head2 lookup_from_env
 
-Tries to find environments variables that start with MYRIAD_* and parse them.
+Try to find environment variables that start with C<MYRIAD_*> and parse them.
 
 =cut
 
 method lookup_from_env () {
-    $config->{$_} //= delete $ENV{'MYRIAD_' . uc($_)} for grep { exists $ENV{'MYRIAD_' . uc($_)} } keys %DEFAULTS;
-    map {
-        s/(MYRIAD_SERVICES?_)//;
-        $self->parse_subargs(lc($_), $config->{services} //= {}, $ENV{$1 . $_});
-    } (grep {$_ =~ /MYRIAD_SERVICES?_/} keys %ENV);
+    $config->{$_} //= $ENV{'MYRIAD_' . uc($_)} for grep {
+        exists $ENV{'MYRIAD_' . uc($_)}
+    } keys %DEFAULTS;
+
+    for(map { /^MYRIAD_SERVICE_(.*)$/ ? [ $_, $1 ] : () } sort keys %ENV) {
+        my ($k, $service) = @$_;
+        $self->parse_subargs(
+            lc($service),
+            $config->{services},
+            $ENV{$k},
+        );
+    }
 }
 
 =head2 lookup_from_file
@@ -341,7 +346,7 @@ it takes
 
 =item * C<pkg> - The package name of the service, will be used to lookup for generic config
 
-=item * C<service_name> - The current service name either from the registry or as it bassed by the user, useful for instances config
+=item * C<service_name> - The current service name either from the registry or as it bassed by the user, useful for instance config
 
 =back
 
@@ -350,11 +355,11 @@ it takes
 async method service_config ($pkg, $service_name) {
     my $service_config = {};
     my $instance = $service_name =~ s/\[(.*)\]$// && $1;
-    my $available_config = $config->{services}->{$service_name}->{configs};
+    my $available_config = $config->{services}->{$service_name}->{config};
 
     my $instance_overrides = {};
     $instance_overrides =
-        $config->{services}->{$service_name}->{instances}->{$instance}->{configs} if $instance;
+        $config->{services}->{$service_name}->{instance}->{$instance}->{config} if $instance;
     if(my $declared_config = $SERVICES_CONFIG{$pkg}) {
         for my $key (keys $declared_config->%*) {
             my $value;
@@ -436,7 +441,7 @@ async method listen_for_updates () {
             $log->trace('Config: transport do not support keyspace notifications');
         }
     } else {
-        $log->warn('Config: Storage is not initiated, cannot listen to configs updates');
+        $log->warn('Config: Storage is not initiated, cannot listen to config updates');
     }
 }
 

--- a/t/config.t
+++ b/t/config.t
@@ -97,6 +97,7 @@ subtest 'It should parse commandline args correctly' => sub {
         $is_service_instance_ok->($args);
 
     };
+    done_testing;
 };
 
 subtest 'It should read config from ENV correctly' => sub {
@@ -104,6 +105,7 @@ subtest 'It should read config from ENV correctly' => sub {
     $config->clear_all;
 
     # To detect standard config from ENV
+    local %ENV = %ENV;
     $ENV{"MYRIAD_$_"} = 'test_value' for map {uc($_)} keys %regular_config;
     is(exception {
         $config->lookup_from_env();
@@ -131,6 +133,7 @@ subtest 'It should read config from ENV correctly' => sub {
     ok($services_config->{'fake.name'}, 'service name parsed correctly');
     ok(my $instance_config = $services_config->{'fake.name'}->{instance}->{demo}, 'service instance has been parsed correctly');
     is($instance_config->{config}->{env_key}, 'instance value from env', 'instance config has been parsed correctly');
+    done_testing;
 };
 
 subtest 'It should read config from config file correctly' => sub {
@@ -143,9 +146,11 @@ subtest 'It should read config from config file correctly' => sub {
     is($config->key('transport'), 'value_from_file', 'framework config has been passed correctly');
     is($config->key('services')->{'fake.name'}->{config}->{key}, 'value from file', 'services config has been passed correctly');
     is($config->key('services')->{'fake.name'}->{instance}->{demo}->{config}->{key}, 'instance value from file', 'instance config has been passed correctly');
+    done_testing;
 };
 
 subtest 'It should keep config source priority correct' => sub {
+    local %ENV = %ENV;
     # commandline args should take over ENV
     $ENV{MYRIAD_TRANSPORT} = 'env_prio';
     my $args = ['--transport', 'cmd_prio'];
@@ -170,12 +175,14 @@ subtest 'It should keep config source priority correct' => sub {
     # Default by default
     $config = Myriad::Config->new();
     is($config->key('transport'), $defaults{'transport'}, 'default is correct');
+    done_testing;
 };
 
 subtest 'Special config shortcuts' => sub {
     subtest 'framework config should be returend as Ryu::Obvervable' => sub {
         my $config = Myriad::Config->new();
         isa_ok($config->key('transport'), 'Ryu::Observable', 'correct config container');
+        done_testing;
     };
 
     subtest 'It should infer transport and address' => sub {
@@ -184,6 +191,7 @@ subtest 'Special config shortcuts' => sub {
 
         is($config->key('transport'), 'redis', 'correct transport type');
         is($config->key('transport_redis'), 'redis://somehost:1111', 'correct uri for the correct transport');
+        done_testing;
     };
 
     subtest 'It should configure all transport type implicitly' => sub {
@@ -193,7 +201,9 @@ subtest 'Special config shortcuts' => sub {
         is($config->key('rpc_transport'), 'memory', 'correct rpc transport');
         is($config->key('subscription_transport'), 'memory', 'correct subscription transport');
         is($config->key('storage_transport'), 'memory', 'correct storage transport');
+        done_testing;
     };
+    done_testing;
 };
 
 done_testing;

--- a/t/config.t
+++ b/t/config.t
@@ -14,38 +14,39 @@ BEGIN { *CORE::GLOBAL::exit = sub(;$) { pass("called exit"); } }
 use Myriad::Config;
 
 my %defaults = %Myriad::Config::DEFAULTS;
+my %regular_config = grep !ref $defaults{$_}, keys %defaults;
 my %shortcuts = %Myriad::Config::FULLNAME_FOR;
 
 subtest 'It should parse commandline args correctly' => sub {
-    my $configs = Myriad::Config->new();
+    my $config = Myriad::Config->new();
     my $args = ['--bad-key', 'value'];
 
     # Bad keys
-    exception { $configs->lookup_from_args($args) };
+    exception { $config->lookup_from_args($args) };
     $log->contains_ok(qr/don't know how to deal with.*bad-key/, 'bad-key was reported');
 
     # Parse full options
-    $args = [ map { "--" . $_ => 'test_value' } keys %defaults ];
-    $configs->lookup_from_args($args);
+    $args = [ map { "--" . $_ => 'test_value' } keys %regular_config ];
+    $config->lookup_from_args($args);
 
-    is($configs->key($_), 'test_value' , "config $_ has been set correctly") for keys %defaults;
+    is($config->key($_), 'test_value' , "config $_ has been set correctly") for keys %regular_config;
 
     # Parse short
     $args = [ map { "-" . $_ => 'test_value' } keys %shortcuts ];
-    $configs->lookup_from_args($args);
+    $config->lookup_from_args($args);
 
-    is($configs->key($_), 'test_value' , "config $_ has been set correctly from shortcut") for values %shortcuts;
+    is($config->key($_), 'test_value' , "config $_ has been set correctly from shortcut") for values %shortcuts;
 
     # key=value format should be accepted
     $args = ['--transport=anything'];
-    $configs->lookup_from_args($args);
+    $config->lookup_from_args($args);
 
-    is($configs->key('transport'), 'anything', 'key=value format is parsed correctly');
+    is($config->key('transport'), 'anything', 'key=value format is parsed correctly');
 
     # Stops at the correct place
     $args = ['--transport', 'memory', '-lib', '/code', 'service'];
 
-    $configs->lookup_from_args($args);
+    $config->lookup_from_args($args);
     cmp_deeply($args, ['service'], 'only args has been consumed');
 
     subtest 'It should parse service related config correctly' => sub {
@@ -53,50 +54,45 @@ subtest 'It should parse commandline args correctly' => sub {
         # We try to configure the same
         my $is_service_config_ok = sub {
             my $args = shift;
-            $configs->lookup_from_args($args);
-            my $service_configs = $configs->key('services');
-            ok($service_configs->{'fake.name'}, 'service name been captured correctly');
-            is($service_configs->{'fake.name'}->{configs}->{key}, 'value', 'service config been parsed correctly');
+            $config->lookup_from_args($args);
+            my $service_config = $config->key('services');
+            ok($service_config->{'fake.name'}, 'service name been captured correctly');
+            is($service_config->{'fake.name'}->{config}->{key}, 'value', 'service config been parsed correctly') or note explain $service_config;
         };
 
-        # Dynamically parsing services config using . format
-        $configs = Myriad::Config->new;
-        $args = ['--services.fake.name.configs.key', 'value'];
+        # Dynamically parsing service config using . format
+        $config = Myriad::Config->new;
+        $args = ['--service.fake.name.config.key', 'value'];
         $is_service_config_ok->($args);
 
-        # Dynamically parsing services config using _ format
-        $configs = Myriad::Config->new;
-        $args = ['--services_fake_name_configs_key', 'value'];
-        $is_service_config_ok->($args);
-
-        # We should be able to use service (single) and config (single)
-        $configs = Myriad::Config->new;
+        # Dynamically parsing service config using _ format
+        $config = Myriad::Config->new;
         $args = ['--service_fake_name_config_key', 'value'];
         $is_service_config_ok->($args);
 
         my $is_service_instance_ok = sub {
             my $args = shift;
-            $configs->lookup_from_args($args);
-            my $service_configs = $configs->key('services');
-            ok($service_configs->{'fake.name'}, 'service name been captured correctly');
-            my $instance_configs = $service_configs->{'fake.name'}->{instances};
+            $config->lookup_from_args($args);
+            my $service_config = $config->key('services');
+            ok($service_config->{'fake.name'}, 'service name been captured correctly');
+            my $instance_config = $service_config->{'fake.name'}->{instance};
 
-            ok($instance_configs->{demo}, 'instance name been captured correctly');
-            is($instance_configs->{demo}->{configs}->{new_key}, 'value', 'service config been parsed correctly');
+            ok($instance_config->{demo}, 'instance name been captured correctly');
+            is($instance_config->{demo}->{config}->{new_key}, 'value', 'service config been parsed correctly');
         };
 
         # Dynamically parse instance config using . format
-        $configs = Myriad::Config->new;
-        $args = ['--services.fake.name.instances.demo.configs.new_key', 'value'];
+        $config = Myriad::Config->new;
+        $args = ['--service.fake.name.instance.demo.config.new_key', 'value'];
         $is_service_instance_ok->($args);
 
         # Dynamically parsing instance config using _ format
-        $configs = Myriad::Config->new;
-        $args = ['--services_fake_name_instances_demo_configs_new_key', 'value'];
+        $config = Myriad::Config->new;
+        $args = ['--service_fake_name_instance_demo_config_new_key', 'value'];
         $is_service_instance_ok->($args);
 
         # We should be able to use service (single) and instnace (single)
-        $configs = Myriad::Config->new;
+        $config = Myriad::Config->new;
         $args = ['--service_fake_name_instance_demo_config_new_key', 'value'];
         $is_service_instance_ok->($args);
 
@@ -104,95 +100,99 @@ subtest 'It should parse commandline args correctly' => sub {
 };
 
 subtest 'It should read config from ENV correctly' => sub {
-    my $configs = Myriad::Config->new;
-    $configs->clear_all;
+    my $config = Myriad::Config->new;
+    $config->clear_all;
 
     # To detect standard config from ENV
-    $ENV{"MYRIAD_$_"} = 'test_value' for map {uc($_)} keys %defaults;
-    $configs->lookup_from_env();
+    $ENV{"MYRIAD_$_"} = 'test_value' for map {uc($_)} keys %regular_config;
+    is(exception {
+        $config->lookup_from_env();
+    }, undef, 'handle global configuration from environment');
 
-    is($configs->key($_), 'test_value' , "config $_ has been set correctly") for keys %defaults;
+    is($config->key($_), 'test_value' , "config $_ has been set correctly") for keys %regular_config;
 
-    # To pass services' configs
-    $ENV{'MYRIAD_SERVICES_FAKE_NAME_CONFIGS_ENV_KEY'} = 'value from env';
-    $configs->lookup_from_env();
+    # To pass services' config
+    $ENV{'MYRIAD_SERVICE_FAKE_NAME_CONFIG_ENV_KEY'} = 'value from env';
+    is(exception {
+        $config->lookup_from_env();
+    }, undef, 'handle service configuration from environment');
 
-    my $services_config = $configs->key('services');
+    my $services_config = $config->key('services');
     ok($services_config->{'fake.name'}, 'service name parsed correctly');
-    is($services_config->{'fake.name'}->{configs}->{env_key}, 'value from env', 'service config has been parsed correctly');
+    is($services_config->{'fake.name'}->{config}->{env_key}, 'value from env', 'service config has been parsed correctly');
 
-    $configs->clear_all();
+    $config->clear_all();
 
-    # To parse instances config
-    $ENV{'MYRIAD_SERVICES_FAKE_NAME_INSTANCES_DEMO_CONFIGS_ENV_KEY'} = 'instance value from env';
-    $configs->lookup_from_env();
+    # To parse instance config
+    $ENV{'MYRIAD_SERVICE_FAKE_NAME_INSTANCE_DEMO_CONFIG_ENV_KEY'} = 'instance value from env';
+    $config->lookup_from_env();
 
-    $services_config = $configs->key('services');
+    $services_config = $config->key('services');
     ok($services_config->{'fake.name'}, 'service name parsed correctly');
-    ok(my $instance_configs = $services_config->{'fake.name'}->{instances}->{demo}, 'service instance has been parsed correctly');
-    is($instance_configs->{configs}->{env_key}, 'instance value from env', 'instance config has been parsed correctly');
+    ok(my $instance_config = $services_config->{'fake.name'}->{instance}->{demo}, 'service instance has been parsed correctly');
+    is($instance_config->{config}->{env_key}, 'instance value from env', 'instance config has been parsed correctly');
 };
 
 subtest 'It should read config from config file correctly' => sub {
-    my $configs = Myriad::Config->new;
+    my $config = Myriad::Config->new;
 
-    $configs->clear_key('transport');
-    $configs->clear_key('services');
-    $configs->lookup_from_file('t/config.yml');
+    $config->clear_key('transport');
+    $config->clear_key('services');
+    $config->lookup_from_file('t/config.yml');
 
-    is($configs->key('transport'), 'value_from_file', 'framework config has been passed correctly');
-    is($configs->key('services')->{'fake.name'}->{configs}->{key}, 'value from file', 'services config has been passed correctly');
-    is($configs->key('services')->{'fake.name'}->{instances}->{demo}->{configs}->{key}, 'instance value from file', 'instance config has been passed correctly');
+    is($config->key('transport'), 'value_from_file', 'framework config has been passed correctly');
+    is($config->key('services')->{'fake.name'}->{config}->{key}, 'value from file', 'services config has been passed correctly');
+    is($config->key('services')->{'fake.name'}->{instance}->{demo}->{config}->{key}, 'instance value from file', 'instance config has been passed correctly');
 };
 
-subtest 'It should keep configs source priority correct' => sub {
+subtest 'It should keep config source priority correct' => sub {
     # commandline args should take over ENV
     $ENV{MYRIAD_TRANSPORT} = 'env_prio';
     my $args = ['--transport', 'cmd_prio'];
 
-    my $configs = Myriad::Config->new(commandline => $args);
-    is($configs->key('transport'), 'cmd_prio', 'command line priority is more than the env variables');
+    my $config = Myriad::Config->new(commandline => $args);
+    is($config->key('transport'), 'cmd_prio', 'command line priority is more than the env variables');
 
     # Env should take over file
     $args = ['--config_path', 't/config.yml'];
     $ENV{MYRIAD_TRANSPORT} = 'env_prio';
 
-    $configs = Myriad::Config->new(commandline => $args);
-    is($configs->key('transport'), 'env_prio', 'env variables priority is more than the file data');
+    $config = Myriad::Config->new(commandline => $args);
+    is($config->key('transport'), 'env_prio', 'env variables priority is more than the file data');
 
     # File take over defaults
     $args = ['--config_path', 't/config.yml'];
     delete $ENV{MYRIAD_TRANSPORT};
 
-    $configs = Myriad::Config->new(commandline => $args);
-    is($configs->key('transport'), 'value_from_file', 'config file priority is more than the default values');
+    $config = Myriad::Config->new(commandline => $args);
+    is($config->key('transport'), 'value_from_file', 'config file priority is more than the default values');
 
     # Default by default
-    $configs = Myriad::Config->new();
-    is($configs->key('transport'), $defaults{'transport'}, 'default is correct');
+    $config = Myriad::Config->new();
+    is($config->key('transport'), $defaults{'transport'}, 'default is correct');
 };
 
 subtest 'Special config shortcuts' => sub {
     subtest 'framework config should be returend as Ryu::Obvervable' => sub {
-        my $configs = Myriad::Config->new();
-        isa_ok($configs->key('transport'), 'Ryu::Observable', 'correct config container');
+        my $config = Myriad::Config->new();
+        isa_ok($config->key('transport'), 'Ryu::Observable', 'correct config container');
     };
 
     subtest 'It should infer transport and address' => sub {
         my $args = ['--transport', 'redis://somehost:1111'];
-        my $configs = Myriad::Config->new(commandline => $args);
+        my $config = Myriad::Config->new(commandline => $args);
 
-        is($configs->key('transport'), 'redis', 'correct transport type');
-        is($configs->key('transport_redis'), 'redis://somehost:1111', 'correct uri for the correct transport');
+        is($config->key('transport'), 'redis', 'correct transport type');
+        is($config->key('transport_redis'), 'redis://somehost:1111', 'correct uri for the correct transport');
     };
 
     subtest 'It should configure all transport type implicitly' => sub {
         my $args = ['--transport', 'memory'];
-        my $configs = Myriad::Config->new(commandline => $args);
+        my $config = Myriad::Config->new(commandline => $args);
 
-        is($configs->key('rpc_transport'), 'memory', 'correct rpc transport');
-        is($configs->key('subscription_transport'), 'memory', 'correct subscription transport');
-        is($configs->key('storage_transport'), 'memory', 'correct storage transport');
+        is($config->key('rpc_transport'), 'memory', 'correct rpc transport');
+        is($config->key('subscription_transport'), 'memory', 'correct subscription transport');
+        is($config->key('storage_transport'), 'memory', 'correct storage transport');
     };
 };
 

--- a/t/config.yml
+++ b/t/config.yml
@@ -2,10 +2,10 @@ transport: value_from_file
 
 services:
     fake.name:
-        configs:
+        config:
             key: value from file
-        instances:
+        instance:
             demo:
-                configs:
+                config:
                     key: instance value from file
 


### PR DESCRIPTION
We have some cases where words are allowed in singular or plural form, which is extremely problematic for code maintenance:

- `instance`
- `service`
- `config`

These should be consistently singular throughout the codebase and config files.