### PR TITLE
Fix usage of Future helpers

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+
+1.000     2022-09-05 10:25:25+08:00 Asia/Singapore
     [API changes]
     - The --service_name parameter has been dropped, since it makes no sense when
     used with multiple services or instances

--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ modules under that immediate namespace will be loaded
 - if it contains `::`, it's treated as a comma-separated list of service module names to load
 - a `-` prefix is a standard getopt parameter
 
+## transport
+
+Returns the [Myriad::Transport](https://metacpan.org/pod/Myriad%3A%3ATransport) instance according to the config value.
+
+it's designed to be used by tests, so be careful before using it in the framework code.
+
+it takes a single param
+
+- component - the RPC, Subscription or storage in lower case
+
 ## redis
 
 The [Net::Async::Redis](https://metacpan.org/pod/Net%3A%3AAsync%3A%3ARedis) (or compatible) instance used for service coördination.
@@ -308,4 +318,4 @@ Deriv Group Services Ltd. `DERIV@cpan.org`
 
 # LICENSE
 
-Copyright Deriv Group Services Ltd 2020-2021. Licensed under the same terms as Perl itself.
+Copyright Deriv Group Services Ltd 2020-2022. Licensed under the same terms as Perl itself.

--- a/cpanfile
+++ b/cpanfile
@@ -9,7 +9,7 @@ requires 'Syntax::Keyword::Try', '>= 0.27';
 requires 'Syntax::Keyword::Defer', '>= 0.07';
 requires 'Syntax::Keyword::Match', '>= 0.09';
 requires 'Syntax::Operator::Equ', '>= 0.03';
-requires 'Future', '>= 0.48';
+requires 'Future', '>= 0.49';
 requires 'Future::Queue';
 requires 'Future::AsyncAwait', '>= 0.58';
 requires 'Future::IO', '>= 0.11';

--- a/lib/Myriad/RPC/Implementation/Memory.pm
+++ b/lib/Myriad/RPC/Implementation/Memory.pm
@@ -66,7 +66,7 @@ async method start () {
             my $messages = await $transport->read_from_stream_by_consumer($rpc->{stream}, $self->group_name, hostname());
             await $self->process_stream_messages(rpc => $rpc, messages => $messages) if %$messages;
         }), foreach => [ $self->rpc_list->@* ], concurrent => scalar $self->rpc_list->@*);
-        await Future::wait_any($should_shutdown, $self->loop->delay_future(after => 0.1));
+        await Future->wait_any($should_shutdown, $self->loop->delay_future(after => 0.1));
     }
 }
 


### PR DESCRIPTION
With Future::XS, the `Future` package will end up pushing most of the work over to inherited methods. This causes direct function calls such as `Future::wait_any` to fail (should be `Future->wait_any` instead). Fixes test failures seen in Future `0.48_001`.