### PR TITLE
Support for faster Redis implementation

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,10 @@ Revision history for {{$dist->name}}
     - Future::AsyncAwait - updated to v0.61 for some minor bugfixes and Future::XS
     compatibility
 
+    [New features]
+    - support for Net::Async::Redis::XS, set the environment variable `PERL_REDIS_XS` to `1`
+    to load and use the XS versions for better performance
+
 1.001     2022-11-11 09:42:07+08:00 Asia/Singapore
     [Bugs fixed]
     - Latest Future (and Future::XS) were failing tests due to `Future->needs_all`

--- a/cpanfile
+++ b/cpanfile
@@ -55,6 +55,7 @@ requires 'Log::Any::Adapter::OpenTracing', '>= 0.001';
 requires 'Metrics::Any::Adapter::Statsd', '>= 0.03';
 # Transport
 requires 'Net::Async::Redis', '>= 3.022';
+recommends 'Net::Async::Redis::XS', '>= 0.004';
 requires 'Net::Async::HTTP', '>= 0.48';
 requires 'Net::Async::HTTP::Server', '>= 0.13';
 # Introspection


### PR DESCRIPTION
Use [Net::Async::Redis::XS](https://metacpan.org/pod/Net::Async::Redis::XS) if installed _and_ the `PERL_REDIS_XS` environment variable is set.